### PR TITLE
Fix few typo(s) in WIN32, Fix '$init' is not accessible from the current context when compiling slang

### DIFF
--- a/assets/shaders/common/Shading.slang
+++ b/assets/shaders/common/Shading.slang
@@ -1240,6 +1240,11 @@ public struct FPathTracingRendererV2
         OutSingleSpecular = Bindless.GetStorageTexture<float4>(Bindless.RT_SINGLE_SPECULAR);
     }
 
+    public __init()
+    {
+        
+    }
+
     int2 pixel_;
     uint2 size_;
     uint4 RandomSeed_;

--- a/src/Runtime/NextAnimation.cpp
+++ b/src/Runtime/NextAnimation.cpp
@@ -84,8 +84,8 @@ void NextAnimation::Tick(double deltaSeconds)
 
 #if WIN32
         // Selects joint matrices.
-        const ozz::math::Float4x4& parent = models_[parent_id];
-        const ozz::math::Float4x4& current = models_[i];
+        const ozz::math::Float4x4& parent = models[parentId];
+        const ozz::math::Float4x4& current = models[i];
 
         ozz::math::SimdFloat4 p0 = ozz::math::TransformPoint(parent, {0,0,0,1});
         ozz::math::SimdFloat4 p1 = ozz::math::TransformPoint(current, {0,0,0,1});

--- a/src/Vulkan/DeviceMemory.cpp
+++ b/src/Vulkan/DeviceMemory.cpp
@@ -101,7 +101,7 @@ DeviceMemory::DeviceMemory(
 	VkExportMemoryAllocateInfoKHR exportMemoryAllocateInfo{};
 	exportMemoryAllocateInfo.sType       = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR;
 #if WIN32 && !defined(__MINGW32__)
-	export_memory_allocate_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR;
+	exportMemoryAllocateInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR;
 #else
 	exportMemoryAllocateInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 #endif
@@ -117,7 +117,7 @@ DeviceMemory::DeviceMemory(
 	if(external)
 	{
 #if WIN32 && !defined(__MINGW32__)
-		export_memory_allocate_info.pNext = &export_memory_win32_handle_info;
+		exportMemoryAllocateInfo.pNext = &export_memory_win32_handle_info;
 #endif
 		allocInfo.pNext = &exportMemoryAllocateInfo;
 	}

--- a/src/Vulkan/Image.cpp
+++ b/src/Vulkan/Image.cpp
@@ -46,7 +46,7 @@ Image::Image(
 	VkExternalMemoryImageCreateInfo externalMemoryImageInfo{};
 	externalMemoryImageInfo.sType       = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
 #if WIN32 && !defined(__MINGW32__)
-	external_memory_image_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+	externalMemoryImageInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
 #else
 	externalMemoryImageInfo.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 #endif


### PR DESCRIPTION
as title